### PR TITLE
Update _get_account_id to ignore non-brokerage accounts.

### DIFF
--- a/vanguard/account.py
+++ b/vanguard/account.py
@@ -52,7 +52,7 @@ class AllAccount:
            string: account_id
         """
         account_id = selector.query_selector("span > span > span > span").inner_text()
-        if len(account_fields := account_id.split("—")) == 3:
+        if len(account_fields := account_id.split("—")) == 3 and ("brokerage" in account_fields[1].lower()):
             return account_fields[2].strip().replace("*", "")
         return None
 


### PR DESCRIPTION
Non-brokerage accounts will cause a timeout and crash the bot. This fixes that by checking for "brokerage" in the name, which matches the list of trade-able accounts in the order-page dialog.

However, this will also not show holdings for these accounts, which is probably appropriate given that they are edge-cases like cash-plus.