### PR TITLE
Sleep for 1s before & after entering # of shares in an order.

### DIFF
--- a/vanguard/order.py
+++ b/vanguard/order.py
@@ -152,7 +152,7 @@ class Order:
                 "xpath=//label[text()='Sell']"
             )
             sell_btn.click()
-
+        sleep(1)
         quantity_box = self.session.page.wait_for_selector(
             "//input[@placeholder='Enter Shares']"
         )

--- a/vanguard/order.py
+++ b/vanguard/order.py
@@ -158,7 +158,8 @@ class Order:
         )
         quantity_box.fill("")
         quantity_box.type(str(quantity))
-
+        sleep(1)
+        
         if price_type == "MARKET":
             self.session.page.wait_for_selector("//label[text()='Market']").click()
         elif price_type == "LIMIT":

--- a/vanguard/order.py
+++ b/vanguard/order.py
@@ -159,7 +159,6 @@ class Order:
         quantity_box.fill("")
         quantity_box.type(str(quantity))
         sleep(1)
-        
         if price_type == "MARKET":
             self.session.page.wait_for_selector("//label[text()='Market']").click()
         elif price_type == "LIMIT":


### PR DESCRIPTION
Add a sleep(1) before and after # of shares are input for an order, since there are errors sporadically that this field isn't filled in. This could be since it is moving a bit too quickly.